### PR TITLE
Fixed & refractored Dockerfile runtime failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
+# Install 
 FROM node:12
+
+# Set as default directory
 WORKDIR /
-COPY package*.json /app/
+
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+COPY package*.json ./
+
+# Install dependencies
 RUN npm install
-COPY . /app/
+
+# Bundle app source
+COPY . .
+
+# Run 
 CMD ["npm", "start"]


### PR DESCRIPTION
I fixed faulty copy commands within the Dockerfile. I replaced `COPY package*.json /app/`, with `COPY package*.json ./`. The second change I made was replacing `COPY . /app/` with `COPY . .`. Now docker will be able to copy both package.json && package-lock.json without runtime failure.